### PR TITLE
Update YmcaSyncCommands.php - Fix null

### DIFF
--- a/src/Commands/YmcaSyncCommands.php
+++ b/src/Commands/YmcaSyncCommands.php
@@ -57,6 +57,9 @@ class YmcaSyncCommands extends DrushCommands {
     $activeSyncers = $configFactory->get('ymca_sync.settings')->get('active_syncers');
     $syncers = \Drupal::service('ymca_sync.sync_repository')->getSyncers();
     $result = [];
+    if (!$activeSyncers) {
+      return new RowsOfFields($result);
+    }
     foreach ($syncers as $syncer) {
       $result[] = [
         'active' => in_array($syncer, $activeSyncers) ? 'active' : 'disabled',


### PR DESCRIPTION
```sh
drush en -y openy_pef_gxp_sync
 [success] Successfully enabled: openy_pef_gxp_sync
root@openy:/var/www/build3080# drush yn-sync:list
 [warning] in_array() expects parameter 2 to be array, null given YmcaSyncCommands.php:62
disabled	openy_pef_gxp_sync.syncer
root@openy:/var/www/build3080# drush yn-sync:enable openy_pef_gxp_sync.syncer
 [warning] in_array() expects parameter 2 to be array, null given YmcaSyncCommands.php:86
root@openy:/var/www/build3080# drush yn-sync:list
active	openy_pef_gxp_sync.syncer
```