### PR TITLE
Resolve non-existent service ymca_sync.sync_repository error.

### DIFF
--- a/src/DependencyInjection/Compiler/YmcaSyncPass.php
+++ b/src/DependencyInjection/Compiler/YmcaSyncPass.php
@@ -23,6 +23,9 @@ class YmcaSyncPass implements CompilerPassInterface {
     }
 
     $definition = new Definition('Drupal\ymca_sync\SyncRepository');
+    // As of Symfony 5.2 all services are private by default, but in Drupal
+    // services are still public. See https://www.drupal.org/node/3194517
+    $definition->setPublic(TRUE);
     $container->setDefinition('ymca_sync.sync_repository', $definition);
 
     $definition = $container->getDefinition('ymca_sync.sync_repository');


### PR DESCRIPTION
After update to Drupal 10, the following command

```
drush yn-sync my_data.syncer
```

produces the error:

```
In Container.php line 157:
  You have requested a non-existent service "ymca_sync.sync_repository".
```

The error happens because the services in Symfony 5 and above are now created private by default. Drupal expects services to be explicitly set to public. More info found here: https://www.drupal.org/node/3194517